### PR TITLE
Adjust wording

### DIFF
--- a/lib/credo_runtime_only/check/warning/system_get_env.ex
+++ b/lib/credo_runtime_only/check/warning/system_get_env.ex
@@ -2,7 +2,7 @@ defmodule CredoRuntimeOnly.Check.Warning.SystemGetEnv do
   @moduledoc false
 
   @checkdoc """
-  Checks for calls to System.get_env/0/1. Calls to this are compile time lookups instead of Runtime lookups.
+  Checks for calls to System.get_env/0/1. Calls to this can be compile time lookups instead of Runtime lookups if used incorrectly.
 
   In most cases, runtime lookups are desired and compile time lookups should be avoided.
   """


### PR DESCRIPTION
@mackeyja92 thanks for the lib! Very useful.

I wanted to adjust the wording on the message we display. Calls to `System.get_env()` are not always compile time lookups. The tool was not the issue, it was the usage of the tool that was.

Hope this helps and can make things clearer for users.

Thanks!

PG